### PR TITLE
Add in the ignoreValidation to the action yaml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
     required: false
 
   ignoreValidation:
-    description: 'Bypasses validation errors (not recommended)'
+    description: 'If true, bypasses validation errors (not recommended)'
     default: false
     required: false
 


### PR DESCRIPTION
Fixes #132 

Otherwise the latest version cannot be used, for you'll get this error.

```
D:\a\_actions\neilenns\streamdeck-cli-pack\v1.2.10\node_modules\@actions\core\lib\core.js:154
    throw new TypeError(`Input does not meet YAML 1.2 "Core Schema" specification: ${name}\n` +
^
TypeError: Input does not meet YAML 1.2 "Core Schema" specification: ignoreValidation
Support boolean input list: `true | True | TRUE | false | False | FALSE`
    at Object.getBooleanInput (D:\a\_actions\neilenns\streamdeck-cli-pack\v1.2.10\node_modules\@actions\core\lib\core.js:154:1)
    at run (D:\a\_actions\neilenns\streamdeck-cli-pack\v1.2.10\src\main.js:31:1)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional input, ignoreValidation, to allow runs to continue by bypassing validation errors (not recommended). Defaults to false and is not required.
  * Maintains backward compatibility; existing workflows behave unchanged unless the new input is explicitly set.

* **Chores**
  * Exposed the new input in the action's public configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->